### PR TITLE
Bastilla, Fuel Barrel, and Catapult Initial Upload

### DIFF
--- a/Patches/Manned/Ballista.xml
+++ b/Patches/Manned/Ballista.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationSequence">
+		<operations>
+
+		  <!-- ========== Ballista - Base ========== -->
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFES_Turret_Ballista"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[defName="VFES_Turret_Ballista"]/comps/li[@Class="CompProperties_Refuelable"]</xpath>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFES_Turret_Ballista"]/building</xpath>
+				<value>
+					<building>
+						<turretBurstWarmupTime>1</turretBurstWarmupTime>
+						<turretBurstCooldownTime>1</turretBurstCooldownTime>
+						<ai_combatDangerous>true</ai_combatDangerous>	
+						<turretGunDef>VFES_Gun_BallistaTurret</turretGunDef>
+						<turretTopGraphicPath>Things/Building/Ballista/TurretBallista_Top</turretTopGraphicPath>
+						<turretTopDrawSize>3</turretTopDrawSize>
+						<turretTopOffset>(0, 0.05)</turretTopOffset>
+					</building>
+				</value>
+			</li>
+
+		  <!-- ========== Ballista - Weapon ========== -->
+		  <li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+			<defName>VFES_Gun_BallistaTurret</defName>
+			<statBases>
+			  <SightsEfficiency>1</SightsEfficiency>
+			  <ShotSpread>1</ShotSpread>
+			  <SwayFactor>1</SwayFactor>
+			  <Bulk>4.00</Bulk>
+			  <RangedWeapon_Cooldown>2</RangedWeapon_Cooldown>
+			</statBases>
+			<Properties>
+			  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			  <hasStandardCommand>true</hasStandardCommand>
+			  <defaultProjectile>Pilum_MachineFired</defaultProjectile>
+			  <warmupTime>1.4</warmupTime>
+			  <range>44</range>
+			  <soundCast>VFES_Shot_Ballista</soundCast>
+			  <soundCastTail>GunTail_Heavy</soundCastTail>
+			  <recoilPattern>Mounted</recoilPattern>
+			</Properties>
+			<AmmoUser>
+			  <magazineSize>1</magazineSize>
+			  <reloadTime>8</reloadTime>
+			  <spawnUnloaded>true</spawnUnloaded>
+			  <ammoSet>AmmoSet_Javelins</ammoSet>
+			</AmmoUser>
+			<FireModes>
+				<aiAimMode>AimedShot</aiAimMode>
+				<noSnapshot>true</noSnapshot>
+				<noSingleShot>false</noSingleShot>
+			</FireModes>
+		  </li>
+		  
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFES_Gun_BallistaTurret"]/weaponTags</xpath>
+				<value>
+					<li>TurretGun</li>
+				</value>
+			</li>
+
+			<!-- ==========  Machine Fired Javelin =========== -->
+			<!-- Def -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/CombatExtended.AmmoSetDef[defName="AmmoSet_Javelins"]/ammoTypes</xpath>
+				<value>
+					<Pila>Pilum_MachineFired</Pila>
+				</value>
+			</li>
+
+			<!-- Projectile -->			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs</xpath>
+				<value>
+					<ThingDef Class="CombatExtended.AmmoDef" ParentName="BasePilumProjectile">
+						<defName>Pilum_MachineFired</defName>
+						<label>pilum (fired)</label>
+						<projectile Class="CombatExtended.ProjectilePropertiesCE">
+							<damageAmountBase>25</damageAmountBase>
+							<speed>59</speed>
+							<armorPenetrationBase>0.38</armorPenetrationBase>
+							<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 2.5 javelins per resource -->
+							<preExplosionSpawnThingDef>Pila</preExplosionSpawnThingDef>
+						</projectile>
+					</ThingDef>
+				</value>
+			</li>
+			
+		</operations>	
+	</Operation>
+
+</Patch>			

--- a/Patches/Manned/Catapult.xml
+++ b/Patches/Manned/Catapult.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationSequence">
+		<operations>
+
+
+		  <!-- ========== Catapult - Base ========== -->
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFES_Turret_Catapult"]/thingClass</xpath>
+				<value>
+					<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="VFES_Turret_Catapult"]/building</xpath>
+				<value>
+					<spawnedConceptLearnOpportunity>CE_MortarDirectFire</spawnedConceptLearnOpportunity>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFES_Turret_Catapult"]/building/turretBurstWarmupTime</xpath>
+				<value>
+					<turretBurstWarmupTime>1</turretBurstWarmupTime>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="VFES_Turret_Catapult"]/building/turretBurstCooldownTime</xpath>
+				<value>
+					<turretBurstCooldownTime>1</turretBurstCooldownTime>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[defName="VFES_Turret_Catapult"]/inspectorTabs</xpath>
+			</li>
+
+		  <!-- ========== Catapult - Weapon ========== -->			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName="VFES_Artillery_Catapult"]</xpath>
+				<value>
+					<statBases>
+					  <SightsEfficiency>0.5</SightsEfficiency>
+					</statBases>
+				</value>
+			</li>
+		  
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFES_Artillery_Catapult"]/comps</xpath>
+				<value>
+					  <li Class="CombatExtended.CompProperties_Charges">
+						<chargeSpeeds>
+						  <li>30</li>
+						  <li>50</li>
+						  <li>70</li>
+						  <li>90</li>
+						</chargeSpeeds>
+					  </li>
+					  <li Class="CombatExtended.CompProperties_AmmoUser">
+						<magazineSize>1</magazineSize>
+						<reloadTime>12</reloadTime>
+						<spawnUnloaded>true</spawnUnloaded>
+						<ammoSet>AmmoSet_81mmMortarShell</ammoSet>
+					  </li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName = "VFES_Artillery_Catapult"]/verbs</xpath>
+				<value>
+					<verbs>
+					  <li Class="CombatExtended.VerbPropertiesCE">
+						<verbClass>CombatExtended.Verb_ShootMortarCE</verbClass>
+						<forceNormalTimeSpeed>false</forceNormalTimeSpeed>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_81mmMortarShell_HE</defaultProjectile>
+						<warmupTime>4</warmupTime>
+						<minRange>30</minRange>
+						<range>500</range>
+						<burstShotCount>1</burstShotCount>
+						<soundCast>Bow_Recurve</soundCast>
+						<muzzleFlashScale>0</muzzleFlashScale>
+						<indirectFirePenalty>0.2</indirectFirePenalty>
+						<targetParams>
+						  <canTargetLocations>true</canTargetLocations>
+						</targetParams>
+					  </li>
+					</verbs>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[defName = "VFES_Artillery_Catapult"]/building/fixedStorageSettings</xpath>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[defName = "VFES_Artillery_Catapult"]/building/defaultStorageSettings</xpath>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFES_Artillery_Catapult"]/weaponTags</xpath>
+				<value>
+					  <li>TurretGun</li>
+				</value>
+			</li>
+
+			<li Class="PatchOperationRemove">
+				<xpath>/Defs/ThingDef[defName = "VFES_Artillery_Rock"]</xpath>
+			</li>
+
+		</operations>	
+	</Operation>
+
+</Patch>			

--- a/Patches/Static/ExplosiveBarrel.xml
+++ b/Patches/Static/ExplosiveBarrel.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+
+			<!-- ========== Explosive Barrel ========== -->
+			<Operation Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VFES_ChemfuelBarrel"]/comps/li[@Class="CompProperties_Explosive"]</xpath>
+				<value>
+					<li Class="CompProperties_Explosive">
+						<explosiveDamageType>PrometheumFlame</explosiveDamageType>
+						<explosiveRadius>5.9</explosiveRadius>
+						<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
+						<preExplosionSpawnChance>0.4</preExplosionSpawnChance>
+						<startWickHitPointsPercent>0.95</startWickHitPointsPercent>						
+						<wickTicks>
+						  <min>0</min>
+						  <max>30</max>
+						</wickTicks>						
+					</li>
+				</value>
+			</Operation>
+
+</Patch>	


### PR DESCRIPTION
- Patched ballista.
- Patched new, longer range javelin projectile for ballista.
- Initial, functional patch of catapult, with 81mm mortar shell as placeholder projectile.
- Swapped fuel barrel explosion to CE's prometheum, for better fire bombs. May need to up filth spawn chance for better spread on detonation.